### PR TITLE
Parse and use packed OOB data, scan 'dirty' FS images and other small fixes

### DIFF
--- a/src/yaffshiv
+++ b/src/yaffshiv
@@ -515,14 +515,44 @@ class YAFFSParser(YAFFS):
     def __exit__(self, a, b, c):
         return None
 
+    class scanned_data():
+        def __init__(self):
+            self.entries = []
+            self.spares = {}
+        def append(self, data):
+            if type(data) is YAFFSEntry:
+                self.entries.append(data)
+            if type(data) is YAFFSSpare:
+                current = self.spares.get(data.obj_id, [])
+                current.append(data)
+                self.spares[data.obj_id] = current
+
+    def scan_fs(self):
+        self.scanned_data = self.scanned_data()
+        while self.offset < self.data_len:
+            spare = None
+            current_offset = self.offset
+            (obj_hdr_data, obj_hdr_spare) = self.read_block()
+            try:
+                obj_hdr = YAFFSEntry(obj_hdr_data, obj_hdr_spare, self.config)
+            except YAFFSException as e:
+                self.dbg_write("YAFFSException: {}\n".format(e))
+                obj_hdr = YAFFSSpare(obj_hdr_spare, self.config)
+            self.dbg_write("GOT OBJECT: {}\n".format(obj_hdr))
+            obj_hdr.data_offset = current_offset
+            self.scanned_data.append(obj_hdr)
+        self.dbg_write("FOUND {} FS objects\n".format(len(self.scanned_data.entries)))
+        self.offset = 0
+        return self.scanned_data
+
     def next_entry(self):
         '''
         Yields the next object in the YAFFS file system (instance of YAFFSEntry)
         '''
-        while self.offset < self.data_len:
-            # Read and parse the object header data
-            (obj_hdr_data, obj_hdr_spare) = self.read_block()
-            obj_hdr = YAFFSEntry(obj_hdr_data, obj_hdr_spare, self.config)
+        for entry in self.scanned_data.entries:
+            obj_hdr = entry
+            self.dbg_write("GOT OBJECT: {}\n".format(obj_hdr))
+            self.offset = obj_hdr.data_offset
 
             # Sanity check the file name. This is done primarily for cases where there is trailing data
             # at the end of the YAFFS file system, so if we're processing bogus data then the file name
@@ -579,6 +609,17 @@ class YAFFSExtractor(YAFFS):
         Must be called before all other methods in this class.
         '''
         with YAFFSParser(self.data, self.config) as parser:
+            parser.scan_fs()
+            self.dbg_write("Scanned data:\n")
+            for i in parser.scanned_data.entries:
+                self.dbg_write("sequence: {}, obj_id: {}, chunk_id: {}, n_bytes: {}, parent_obj_id: {}, obj_type: {}, name: {}\n".format(
+                i.spare.sequence_id, i.spare.obj_id, i.spare.chunk_id, i.file_size, i.parent_obj_id,
+                i.spare.obj_type, i.name))
+            for dummy in parser.scanned_data.spares.values():
+                for i in dummy:
+                    self.dbg_write("sequence: {}, obj_id: {}, chunk_id: {}, n_bytes: {}, parent_obj_id: {}, obj_type: {}\n".format(
+                    i.sequence_id, i.obj_id, i.chunk_id, i.n_bytes, i.parent_obj_id,
+                    i.obj_type))
             for entry in parser.next_entry():
 
                 # Figure out the full path of this file entry

--- a/src/yaffshiv
+++ b/src/yaffshiv
@@ -375,7 +375,7 @@ class YAFFSSpare(YAFFS):
 
         self.sequence_id = self.read_next(4)
 
-        if self.sequence_id == b'\xff' * 4:
+        if self.sequence_id == 0xFFFFFFFF:
             raise YAFFSException("Bad spare data")
 
         self.obj_id = self.read_next(4)

--- a/src/yaffshiv
+++ b/src/yaffshiv
@@ -521,11 +521,20 @@ class YAFFSParser(YAFFS):
             self.spares = {}
         def append(self, data):
             if type(data) is YAFFSEntry:
+                for entry in self.entries:
+                    if data.yaffs_obj_id == entry.yaffs_obj_id and \
+                        data.spare.sequence_id >= entry.spare.sequence_id:
+                            self.entries.remove(entry)
                 self.entries.append(data)
             if type(data) is YAFFSSpare:
                 current = self.spares.get(data.obj_id, [])
                 current.append(data)
                 self.spares[data.obj_id] = current
+
+        def sort_entries(self):
+            self.entries.sort(
+                key=lambda x: x.parent_obj_id if int(x.yaffs_obj_type) == YAFFS.YAFFS_OBJECT_TYPE_DIRECTORY else x.yaffs_obj_id
+                )
 
     def scan_fs(self):
         self.scanned_data = self.scanned_data()
@@ -541,6 +550,7 @@ class YAFFSParser(YAFFS):
             self.dbg_write("GOT OBJECT: {}\n".format(obj_hdr))
             obj_hdr.data_offset = current_offset
             self.scanned_data.append(obj_hdr)
+        self.scanned_data.sort_entries()
         self.dbg_write("FOUND {} FS objects\n".format(len(self.scanned_data.entries)))
         self.offset = 0
         return self.scanned_data

--- a/src/yaffshiv
+++ b/src/yaffshiv
@@ -648,7 +648,7 @@ class YAFFSExtractor(YAFFS):
                 if Compat.has_key(self.file_paths, entry.parent_obj_id):
                     path = os.path.join(self.file_paths[entry.parent_obj_id], entry.name)
                 else:
-                    if entry.parent_obj_id != 1:
+                    if entry.parent_obj_id != self.YAFFS_OBJECTID_ROOT:
                         self.dbg_write("Warning: File %s is the child of an unknown parent object [%d]!\n" % (entry.name,
                                                                                                               entry.parent_obj_id))
                     path = entry.name

--- a/src/yaffshiv
+++ b/src/yaffshiv
@@ -361,6 +361,11 @@ class YAFFSSpare(YAFFS):
         if not self.config.ecclayout:
             junk = self.read_next(2)
 
+        self.sequence_id = self.read_next(4)
+
+        if self.sequence_id == b'\xff' * 4:
+            raise YAFFSException("Bad spare data")
+
         self.obj_id = self.read_next(4)
         self.chunk_id = self.read_next(4)
 

--- a/src/yaffshiv
+++ b/src/yaffshiv
@@ -650,8 +650,10 @@ class YAFFSExtractor(YAFFS):
                 else:
                     if entry.parent_obj_id != self.YAFFS_OBJECTID_ROOT:
                         self.dbg_write("Warning: File %s is the child of an unknown parent object [%d]!\n" % (entry.name,
-                                                                                                              entry.parent_obj_id))
-                    path = entry.name
+                                                                                                            entry.parent_obj_id))
+                        path = os.path.join(b"lost+found", entry.name)
+                    else:
+                        path = entry.name
 
                 # Store full file paths and entry data for later use
                 self.file_paths[entry.yaffs_obj_id] = path

--- a/src/yaffshiv
+++ b/src/yaffshiv
@@ -355,6 +355,12 @@ class YAFFSSpare(YAFFS):
         '''
         self.data = data
         self.config = config
+        self.has_packed_data = None
+        self.obj_id = None
+        self.chunk_id = None
+        self.parent_obj_id = None
+        self.obj_type = None
+        self.file_size = None
 
         # YAFFS images built without --yaffs-ecclayout have an extra two
         # bytes before the chunk ID. Possibly an unused CRC?
@@ -368,6 +374,16 @@ class YAFFSSpare(YAFFS):
 
         self.obj_id = self.read_next(4)
         self.chunk_id = self.read_next(4)
+        self.n_bytes = self.read_next(4)
+
+        if self.chunk_id & 0x80000000:
+            self.has_packed_data = True
+            self.obj_type = (self.obj_id >> 28).to_bytes(4, 'little')
+            self.obj_id = self.obj_id & ~(0x0f << 28)
+            self.parent_obj_id = self.chunk_id & 0x0FFFFFFF
+            self.chunk_id = 0
+            self.file_size = self.n_bytes
+
 
 class YAFFSEntry(YAFFS):
     '''

--- a/src/yaffshiv
+++ b/src/yaffshiv
@@ -887,7 +887,7 @@ def main():
         elif opt in ["-p", "--page-size"]:
             page_size = int(arg)
         elif opt in ["-o", "--ownership"]:
-            preserve_ownership = True
+            preserve_owner = True
         elif opt in ["-D", "--debug"]:
             debug = True
 

--- a/src/yaffshiv
+++ b/src/yaffshiv
@@ -447,7 +447,7 @@ class YAFFSEntry(YAFFS):
         junk = self.read_next(4)
 
         # File mode and ownership info
-        self.yst_mode = self.read_next(4)
+        self.yst_mode = 0o7777 & self.read_next(4)
         self.yst_uid = self.read_next(4)
         self.yst_gid = self.read_next(4)
 

--- a/src/yaffshiv
+++ b/src/yaffshiv
@@ -384,7 +384,7 @@ class YAFFSSpare(YAFFS):
 
         if self.chunk_id & 0x80000000:
             self.has_packed_data = True
-            self.obj_type = (self.obj_id >> 28).to_bytes(4, 'little')
+            self.obj_type = struct.pack("<I", self.obj_id >> 28)
             self.obj_id = self.obj_id & ~(0x0f << 28)
             self.parent_obj_id = self.chunk_id & 0x0FFFFFFF
             self.chunk_id = 0

--- a/src/yaffshiv
+++ b/src/yaffshiv
@@ -575,7 +575,25 @@ class YAFFSParser(YAFFS):
                 # then the page is padded out with 0xFF. Thus, it is safe to read data
                 # one page at a time via self.read_block until all file data has been
                 # read.
+                file_chunk_id = 1
                 while bytes_remaining:
+                    file_current_chunk = None
+                    file_seq = 0
+                    for en in self.scanned_data.spares.get(entry.yaffs_obj_id):
+                        if en.chunk_id == file_chunk_id and en.sequence_id >= file_seq:
+                            file_current_chunk = en
+                            file_seq = en.sequence_id
+                            self.dbg_write("Found candidate: \n")
+                            self.dbg_write("sequence: {}, obj_id: {}, chunk_id: {}, n_bytes: {}, parent_obj_id: {}, obj_type: {}, file_size: {}\n".format(
+                                en.sequence_id, en.obj_id, en.chunk_id, en.n_bytes, en.parent_obj_id,
+                                en.obj_type, en.file_size))
+                    if not file_current_chunk:
+                        self.dbg_write("DID NOT FUND CHUNK FOR {} Read: {}, remaining: {} !!!\n".format(
+                            entry.name, len(obj_hdr.file_data), bytes_remaining))
+                        break
+
+                    file_chunk_id += 1
+                    self.offset = file_current_chunk.data_offset
                     (data, spare) = self.read_block()
                     if len(data) < bytes_remaining:
                         obj_hdr.file_data += data
@@ -583,6 +601,10 @@ class YAFFSParser(YAFFS):
                     else:
                         obj_hdr.file_data += data[0:bytes_remaining]
                         bytes_remaining = 0
+
+            if obj_hdr.file_size > 0 and bytes_remaining:
+                print("Not all chunks found for {}, skipping".format(obj_hdr.name))
+                continue
 
             yield obj_hdr
 

--- a/src/yaffshiv
+++ b/src/yaffshiv
@@ -361,8 +361,8 @@ class YAFFSSpare(YAFFS):
         if not self.config.ecclayout:
             junk = self.read_next(2)
 
-        self.chunk_id = self.read_next(4)
         self.obj_id = self.read_next(4)
+        self.chunk_id = self.read_next(4)
 
 class YAFFSEntry(YAFFS):
     '''

--- a/src/yaffshiv
+++ b/src/yaffshiv
@@ -410,7 +410,10 @@ class YAFFSEntry(YAFFS):
 
         # Pass the spare data to YAFFSSpare for processing.
         # Keep a copy of this object's ID, as parsed from the spare data, for convenience.
-        self.spare = YAFFSSpare(spare, self.config)
+        try:
+            self.spare = YAFFSSpare(spare, self.config)
+        except YAFFSException as e:
+            raise e
         self.yaffs_obj_id = self.spare.obj_id
 
         # Read in the first four bytes, which are the object type ID,
@@ -540,13 +543,19 @@ class YAFFSParser(YAFFS):
         self.scanned_data = self.scanned_data()
         while self.offset < self.data_len:
             spare = None
+            obj_hdr = None
             current_offset = self.offset
             (obj_hdr_data, obj_hdr_spare) = self.read_block()
             try:
                 obj_hdr = YAFFSEntry(obj_hdr_data, obj_hdr_spare, self.config)
             except YAFFSException as e:
                 self.dbg_write("YAFFSException: {}\n".format(e))
-                obj_hdr = YAFFSSpare(obj_hdr_spare, self.config)
+            if not obj_hdr:
+                try:
+                    obj_hdr = YAFFSSpare(obj_hdr_spare, self.config)
+                except YAFFSException as e:
+                    self.dbg_write("YAFFSException: {}\n".format(e))
+                    continue
             self.dbg_write("GOT OBJECT: {}\n".format(obj_hdr))
             obj_hdr.data_offset = current_offset
             self.scanned_data.append(obj_hdr)

--- a/src/yaffshiv
+++ b/src/yaffshiv
@@ -226,6 +226,12 @@ class YAFFS(object):
     YAFFS_OBJECT_TYPE_HARDLINK  = 4
     YAFFS_OBJECT_TYPE_SPECIAL   = 5
 
+    # Special parent IDs
+    YAFFS_OBJECTID_ROOT         = 1
+    YAFFS_OBJECTID_LOSTNFOUND   = 2
+    YAFFS_OBJECTID_UNLINKED     = 3
+    YAFFS_OBJECTID_DELETED      = 4
+
     # These must be overidden with valid data by any subclass wishing
     # to use the read_long, read_short, read_next or read_block methods.
     #
@@ -402,14 +408,36 @@ class YAFFSEntry(YAFFS):
         # This is filled in later, by YAFFSParser.next_entry
         self.file_data = b''
 
+        # Pass the spare data to YAFFSSpare for processing.
+        # Keep a copy of this object's ID, as parsed from the spare data, for convenience.
+        self.spare = YAFFSSpare(spare, self.config)
+        self.yaffs_obj_id = self.spare.obj_id
+
         # Read in the first four bytes, which are the object type ID,
         # and pass them to YAFFSObjType for processing.
         obj_type_raw = self.read_next(4, raw=True)
-        self.yaffs_obj_type = YAFFSObjType(obj_type_raw, self.config)
+        if self.spare.has_packed_data:
+            if self.spare.obj_type:
+                obj_type_raw = self.spare.obj_type
+            else:
+                raise YAFFSException("No obj_type in spare. Erased block, skipping!")
+        #else:
+        #    raise YAFFSException("No packet tags found! Erased block, skipping!")
 
+        if self.spare.chunk_id:
+            raise YAFFSException("DATA page, skipping!")
+
+        self.yaffs_obj_type = YAFFSObjType(obj_type_raw, self.config)
         # The object ID of this object's parent (e.g., the ID of the directory
         # that a file resides in).
         self.parent_obj_id = self.read_next(4)
+        if self.spare.has_packed_data and self.spare.parent_obj_id:
+            self.parent_obj_id = self.spare.parent_obj_id
+        if self.parent_obj_id in (0, self.YAFFS_OBJECTID_LOSTNFOUND,
+                                  self.YAFFS_OBJECTID_DELETED, self.YAFFS_OBJECTID_UNLINKED):
+            self.dbg_write("Found deleted object, skipping!\n")
+            raise YAFFSException("Found deleted object, skipping!")
+
 
         # File name and checksum (checksum no longer used in YAFFS)
         self.sum_no_longer_used = self.read_next(2)
@@ -466,10 +494,8 @@ class YAFFSEntry(YAFFS):
         else:
             self.file_size = 0
 
-        # Pass the spare data to YAFFSSpare for processing.
-        # Keep a copy of this object's ID, as parsed from the spare data, for convenience.
-        self.spare = YAFFSSpare(spare, self.config)
-        self.yaffs_obj_id = self.spare.obj_id
+        if self.spare.has_packed_data and self.spare.file_size:
+            self.file_size = self.spare.file_size
 
 class YAFFSParser(YAFFS):
     '''


### PR DESCRIPTION
Original yaffshiv utility handles only 'clean' images made with mkyaffs2, which have sequential layout without deleted files/moved/renamed files, erased pages, non-sequential file chunks.

This patchset have several improvements, which allows to unpack real NAND dumps:
* Parse and handle packed tags in spare data
* Detect and skip data pages on FS entries scanning
* Detect deleted files, folders and broken files
* Find and extract non-sequential file chunks